### PR TITLE
[GST-1203] Adds whitelist groups option

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,3 +23,9 @@ users_and_groups:
   #     runas: "ALL=(ALL)"
   #     commands: "NOPASSWD: ALL"
   sudoers: [ ]
+
+  # Use this to only allow certain users contextually
+  # Note that groups will always be created, but users
+  # in groups will only be allowed if they belong to a
+  # group in this list
+  whitelist_groups: []

--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -15,9 +15,13 @@
     group: "{{ item.group | default(omit) }}"
     groups: "{{ item.groups | default([ ]) | join(',') | default(omit) }}"
     name: "{{ item.name }}"
+    password: "{{ item.password | default(omit) }}"
     shell: "{{ item.shell | default('/bin/bash') }}"
     state: "{{ item.state | default(omit) }}"
   with_items: users_and_groups.users
+  when: (not users_and_groups.whitelist_groups) 
+    or ( item.groups is defined and ( item.groups | intersect(users_and_groups.whitelist_groups ))) 
+    or ( item.group is defined and item.group in users_and_groups.whitelist_groups) 
 
 - name: Update home directory permissions
   become: yes
@@ -28,7 +32,12 @@
     path: "/home/{{ item.name }}"
     state: directory
   with_items: users_and_groups.users
-  when: not (item.createhome is defined and not item.createhome)
+  when: (item.createhome is not defined or item.createhome) 
+    and (
+      (not users_and_groups.whitelist_groups) 
+      or ( item.groups is defined and ( item.groups | intersect(users_and_groups.whitelist_groups ))) 
+      or ( item.group is defined and item.group in users_and_groups.whitelist_groups)
+    )
 
 - name: Create .ssh directory
   become: yes
@@ -39,6 +48,9 @@
     mode: 0700
     state: directory
   with_items: users_and_groups.users
+  when: (not users_and_groups.whitelist_groups) 
+    or ( item.groups is defined and ( item.groups | intersect(users_and_groups.whitelist_groups ))) 
+    or ( item.group is defined and item.group in users_and_groups.whitelist_groups) 
 
 - name: Copy ssh auth keys
   become: yes
@@ -46,7 +58,12 @@
     user: "{{ item.name }}"
     key: "{{ lookup('file', item.ssh_key) }}"
   with_items: users_and_groups.users
-  when: item.ssh_key is defined
+  when: (item.ssh_key is defined) 
+    and (
+      (not users_and_groups.whitelist_groups) 
+      or ( item.groups is defined and ( item.groups | intersect(users_and_groups.whitelist_groups ))) 
+      or ( item.group is defined and item.group in users_and_groups.whitelist_groups)
+    )
 
 - name: Ensure /etc/sudoers.d exists
   become: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,3 +5,4 @@
   tags:
     - build
     - configure
+    - maintain

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -44,6 +44,33 @@
             group: voluptatem
             ssh_key: ./lorem.ipsum.pub
 
+    # Check whitelist groups
+    - role: sansible.users_and_groups
+      users_and_groups:
+        groups:
+          - name: nonwhitelist
+          - name: whitelist
+        users:
+          # user not in whitelist with group set
+          - name: nonwhitelistgroup.user
+            group: nonwhitelist
+          # user not in whitelist with groups set
+          - name: nonwhitelistgroups.user
+            groups:
+              - nonwhitelist
+          # user in whitelist with group set
+          - name: whitelistedgroup.user
+            group: whitelist
+            ssh_key: ./lorem.ipsum.pub
+          # user in whitelist with groups set
+          - name: whitelistedgroups.user
+            groups:
+              - nonwhitelist
+              - whitelist
+            ssh_key: ./lorem.ipsum.pub
+        whitelist_groups:
+          - whitelist
+
   post_tasks:
     - name: User lorem.ipsum should have public key added
       become: yes
@@ -55,5 +82,51 @@
     - name: Group ipsum added to sudoers
       become: yes
       shell: "cat /etc/sudoers.d/ipsum | grep -E 'ipsum\\s+ALL=\\(ALL\\)\\s+NOPASSWD: ALL'"
+      tags:
+        - assert
+
+    - name: nonwhitelistgroup.user should not exist
+      become: yes
+      shell: "id -u nonwhitelistgroup.user"
+      register: user_check_result
+      failed_when: "user_check_result.rc == 0"
+      tags:
+        - assert
+
+    - name: nonwhitelistgroups.user should not exist
+      become: yes
+      shell: "id -u nonwhitelistgroups.user"
+      register: user_check_result
+      failed_when: "user_check_result.rc == 0"
+      tags:
+        - assert
+
+    - name: whitelistedgroup.user should exist
+      become: yes
+      shell: "id -u whitelistedgroup.user"
+      register: user_check_result
+      failed_when: "user_check_result.rc != 0"
+      tags:
+        - assert
+
+    - name: User whitelistedgroup.user should have public key added
+      become: yes
+      become_user: whitelistedgroup.user
+      shell: cat /home/whitelistedgroup.user/.ssh/authorized_keys | grep 'ssh-rsa AAAAB3NzaC1yc2E'
+      tags:
+        - assert
+
+    - name: whitelistedgroups.user should exist
+      become: yes
+      shell: "id -u whitelistedgroups.user"
+      register: user_check_result
+      failed_when: "user_check_result.rc != 0"
+      tags:
+        - assert
+
+    - name: User whitelistedgroups.user should have public key added
+      become: yes
+      become_user: whitelistedgroups.user
+      shell: cat /home/whitelistedgroups.user/.ssh/authorized_keys | grep 'ssh-rsa AAAAB3NzaC1yc2E'
       tags:
         - assert


### PR DESCRIPTION
The idea is to group users together by team and role (eg. admin,
smartshop_devs, storelocatore_devs) and then use this whitelist group
option to allow certain groups of users contextually.

For example, in the base image we may only allow the admins group to be
baked in, additional keys can be added post deployment by CI on a per
role basis, so each service role inclue this role and will specify which
groups are allowed.
