### PR TITLE
[GST-2369] Enable sansible users_and_groups to create system users

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,7 @@ users_and_groups:
   #     groups:
   #       - wheel
   #       - users
+  #     system: yes
   #
   users: [ ]
 

--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -42,6 +42,7 @@
     password: "{{ item.password | default(omit) }}"
     shell: "{{ item.shell | default('/bin/bash') }}"
     state: "{{ item.state | default(omit) }}"
+    system: "{{ item.system | default(omit) }}"
   with_items: "{{ users_and_groups.users }}"
   when: (not users_and_groups.whitelist_groups)
     or ( item.groups is defined and ( item.groups | intersect(users_and_groups.whitelist_groups )))


### PR DESCRIPTION
We are building some services that have data that persists between instances on an auxiliary EBS volume. When the service has a UID/GID that is mixed in with the regular users, the id can change between instances when new regular users are added. 
If the service account is created outside of the user accounts uid/gid range, there is far less chance that the service uid/gid will differ between instances.


