### PR TITLE
[GITHUB-21] Readds .ssh dir creation

### DIFF
--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -69,7 +69,24 @@
       or ( item.group is defined and item.group in users_and_groups.whitelist_groups)
     )
 
-- name: Copy ssh auth keys to user home directory
+- name: Create .ssh directory in default user home directory
+  become: yes
+  file:
+    path: /home/{{ item.name }}/.ssh
+    owner: "{{ item.name }}"
+    group: "{{ item.group | default(omit) }}"
+    mode: 0700
+    state: directory
+  with_items: "{{ users_and_groups.users }}"
+  when: (users_and_groups.authorized_keys_dir is none)
+    and (item.state is not defined or item.state != absent)
+    and (
+      (not users_and_groups.whitelist_groups)
+      or ( item.groups is defined and ( item.groups | intersect(users_and_groups.whitelist_groups )))
+      or ( item.group is defined and item.group in users_and_groups.whitelist_groups)
+    )
+
+- name: Copy ssh auth keys to default user home directory
   become: yes
   authorized_key:
     user: "{{ item.name }}"
@@ -85,7 +102,7 @@
       or (item.group is defined and item.group in users_and_groups.whitelist_groups)
     )
 
-- name: Create authorized_keys directory
+- name: Create alternate authorized_keys directory
   become: yes
   file:
     path: "{{ users_and_groups.authorized_keys_dir }}"
@@ -95,7 +112,7 @@
     state: directory
   when: users_and_groups.authorized_keys_dir is not none
 
-- name: Copy ssh auth keys to authorized_keys directory
+- name: Copy ssh auth keys to alternate authorized_keys directory
   become: yes
   authorized_key:
     user: "{{ item.name }}"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -87,6 +87,15 @@
         whitelist_groups:
           - whitelist
 
+    # Test .ssh directory creation for user without any keys
+    - role: sansible.users_and_groups
+      users_and_groups:
+        groups:
+          - name: ssh.dir.test
+        users:
+          - name: ssh.dir.test
+            group: ssh.dir.test
+
   post_tasks:
     - name: User lorem.ipsum should have public key added
       become: yes
@@ -174,5 +183,15 @@
       command: id -g lucifer
       register: user_check_result
       failed_when: user_check_result.stdout != "666"
+      tags:
+        - assert
+
+    - name: ssh.dir.test should have .ssh directory
+      become: yes
+      stat:
+        path: /home/ssh.dir.test/.ssh
+      register: ssh_dir_check
+      failed_when: ssh_dir_check.stat.isdir is not defined
+        or not ssh_dir_check.stat.isdir
       tags:
         - assert


### PR DESCRIPTION
During the recent update that added the ability to install ssh keys in
an alternate directory a small was removed that created a .ssh directory
by default even if no ssh auth keys are specified. Some other roles
(like the GoCD ones) rely on the creation of this dir.

This PR adds this back in and adds a test to ensure the functionality.

Closes #21.