### PR TITLE
Replace deprecated `include` command

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Ensures users and groups
-  include: build.yml
+  import_tasks: build.yml
   tags:
     - build
     - maintain


### PR DESCRIPTION
This PR allows the role to continue to work in the latest ansible. `include` has been removed in the latest versions.